### PR TITLE
fix(url): empty string deserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 
 mod api_calls;
 mod request;
+mod serde_utils;
+
 pub mod structures;
 pub use api_calls::fingerprint_calls::cf_fingerprint;
 

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -1,0 +1,17 @@
+use serde::{de::Error, Deserializer};
+use std::str::FromStr;
+
+pub fn empty_string_is_none<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let string = String::deserialize(deserializer)?;
+
+    if string.is_empty() {
+        Ok(None)
+    } else {
+        let url = Url::from_str(&string).map_err(|e| Error::custom(e.to_string()))?;
+
+        Ok(Some(url))
+    }
+}

--- a/src/structures/file_structs.rs
+++ b/src/structures/file_structs.rs
@@ -3,6 +3,8 @@ use super::{
     *,
 };
 
+use crate::serde_utils::empty_string_is_none;
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
@@ -33,6 +35,7 @@ pub struct File {
     pub download_count: Number,
     /// The file download URL.
     /// Is null if the mod has disabled mod distribution
+    #[serde(deserialize_with = "empty_string_is_none")]
     pub download_url: Option<Url>,
     /// List of game versions this file is relevant for
     pub game_versions: Vec<String>,

--- a/src/structures/mod_structs.rs
+++ b/src/structures/mod_structs.rs
@@ -4,6 +4,8 @@ use super::{
     *,
 };
 
+use crate::serde_utils::empty_string_is_none;
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
@@ -65,8 +67,11 @@ pub struct Mod {
 #[serde(deny_unknown_fields)]
 pub struct ModLinks {
     pub website_url: Url,
+    #[serde(deserialize_with = "empty_string_is_none")]
     pub wiki_url: Option<Url>,
+    #[serde(deserialize_with = "empty_string_is_none")]
     pub issues_url: Option<Url>,
+    #[serde(deserialize_with = "empty_string_is_none")]
     pub source_url: Option<Url>,
 }
 


### PR DESCRIPTION
Sometimes CurseForge's API returns an empty string for URL fields, breaking the `Url` deserialization. This pull request fixes deserialization by creating a custom function for serde to transform any empty string to `None`.

![image](https://user-images.githubusercontent.com/29582786/179380169-fe6bd608-8949-423b-892c-729da13f0353.png)
> Return for `Just Enough Items` `https://api.curseforge.com/v1/mods/238222`
