### PR TITLE
Add NeoForge ModLoaderType

### DIFF
--- a/src/structures/common_structs.rs
+++ b/src/structures/common_structs.rs
@@ -57,4 +57,5 @@ pub enum ModLoaderType {
     LiteLoader = 3,
     Fabric = 4,
     Quilt = 5,
+    NeoForge = 6,
 }


### PR DESCRIPTION
Not in [CurseForge docs](https://docs.curseforge.com/#tocS_ModLoaderType) yet, but ModLoaderType 6 seems to be NeoForge, e.g. [FerriteCore](https://www.curseforge.com/minecraft/mc-mods/ferritecore/files/4574361) (https://api.curseforge.com/v1/mods/429235) responds with "modLoader": 6 for the files with NeoForge.